### PR TITLE
Fixed "clear" method generation when enum is a part of oneof

### DIFF
--- a/generator/support/Field.py
+++ b/generator/support/Field.py
@@ -49,6 +49,8 @@ class Field:
         self.variable_id_name = self.name.upper()
         self.variable_id = self.descriptor.number
         self.template_file = template_filename
+        
+        self.of_type_enum = FieldDescriptorProto.TYPE_ENUM == proto_descriptor.type
 
 
     @staticmethod

--- a/generator/templates/TypeOneof.h
+++ b/generator/templates/TypeOneof.h
@@ -91,6 +91,8 @@ void clear_{{_oneof.get_name()}}()
     case id::{{field.get_variable_id_name()}}:
       {% if field.oneof_allocation_required() %}
       {{field.get_variable_name()}}.~{{field.get_short_type()}}();
+	  {% elif field.of_type_enum %}
+	  {{field.get_variable_name()}} = {{field.get_default_value()}};
       {% else %}
       {{field.get_variable_name()}}.set(0);
       {% endif %}


### PR DESCRIPTION
There is a bug when enum is a part of oneof. Bug exists in develop and in master branches. There is no "set" method in enums, we need to assign a default value to it.

May be there is a better way to know type of filed.