### PR TITLE
Added EmbeddedProtoDescriptor

### DIFF
--- a/generator/support/TypeDefinitions.py
+++ b/generator/support/TypeDefinitions.py
@@ -221,3 +221,11 @@ class MessageDefinition(TypeDefinition):
 
     def get_type(self):
         return self.scope.get_scope_str()
+
+    def get_path(self):
+        path = [self.get_name()]
+        node = self.scope
+        while (node.parent):
+            path.append(node.parent.name)
+            node = node.parent
+        return '.'.join(reversed(path))

--- a/generator/templates/TypeDefMsg.h
+++ b/generator/templates/TypeDefMsg.h
@@ -57,6 +57,11 @@ class {{ typedef.get_name() }} final: public ::EmbeddedProto::MessageInterface
 
     ~{{ typedef.get_name() }}() override = default;
 
+    struct EmbeddedProtoDescriptor {
+        static constexpr char kMessageName[] = "{{ typedef.get_name() }}";
+        static constexpr char kFullTypeName[] = "{{ typedef.get_path() }}";
+    };
+
     {% for enum in typedef.nested_enum_definitions %}
     {{ enum.render(environment)|indent(4) }}
 


### PR DESCRIPTION
Added a feature to the template environment that allows the retrieval of the full path of a message, and used that to create the EmbeddedProtoDescriptor.
The generated path is includes the "package" option in the proto definition, which is part of the scope-tree created by the plugin.