### PR TITLE
Use rvalue references correctly

### DIFF
--- a/generator/templates/FieldBasic_GetSet.h
+++ b/generator/templates/FieldBasic_GetSet.h
@@ -49,13 +49,13 @@ inline void set_{{field.get_name()}}(const {{field.get_cstdint_type()}}& value)
   }
   {{field.get_variable_name()}} = value;
 }
-inline void set_{{field.get_name()}}(const {{field.get_cstdint_type()}}&& value)
+inline void set_{{field.get_name()}}({{field.get_cstdint_type()}}&& value)
 {
   if(FieldNumber::{{field.get_variable_id_name()}} != {{field.get_which_oneof()}})
   {
     init_{{field.get_oneof_name()}}(FieldNumber::{{field.get_variable_id_name()}});
   }
-  {{field.get_variable_name()}} = value;
+  {{field.get_variable_name()}} = std::move(value);
 }
 {% elif field.optional %}
 inline bool has_{{field.get_name()}}() const
@@ -72,10 +72,10 @@ inline void set_{{field.get_name()}}(const {{field.get_cstdint_type()}}& value)
   presence_[presence::index(presence::fields::{{field.get_name().upper()}})] |= presence::mask(presence::fields::{{field.get_name().upper()}});
   {{field.get_variable_name()}} = value;
 }
-inline void set_{{field.get_name()}}(const {{field.get_cstdint_type()}}&& value)
+inline void set_{{field.get_name()}}({{field.get_cstdint_type()}}&& value)
 {
   presence_[presence::index(presence::fields::{{field.get_name().upper()}})] |= presence::mask(presence::fields::{{field.get_name().upper()}});
-  {{field.get_variable_name()}} = value;
+  {{field.get_variable_name()}} = std::move(value);
 }
 inline {{field.get_cstdint_type()}}& mutable_{{field.get_name()}}()
 {
@@ -85,7 +85,7 @@ inline {{field.get_cstdint_type()}}& mutable_{{field.get_name()}}()
 {% else %}
 inline void clear_{{field.get_name()}}() { {{field.get_variable_name()}}.clear(); }
 inline void set_{{field.get_name()}}(const {{field.get_cstdint_type()}}& value) { {{field.get_variable_name()}} = value; }
-inline void set_{{field.get_name()}}(const {{field.get_cstdint_type()}}&& value) { {{field.get_variable_name()}} = value; }
+inline void set_{{field.get_name()}}({{field.get_cstdint_type()}}&& value) { {{field.get_variable_name()}} = std::move(value); }
 inline {{field.get_cstdint_type()}}& mutable_{{field.get_name()}}() { return {{field.get_variable_name()}}.get(); }
 {% endif %}
 inline const {{field.get_cstdint_type()}}& get_{{field.get_name()}}() const { return {{field.get_variable_name()}}.get(); }

--- a/generator/templates/FieldEnum_GetSet.h
+++ b/generator/templates/FieldEnum_GetSet.h
@@ -49,13 +49,13 @@ inline void set_{{field.get_name()}}(const {{field.get_type_as_defined()}}& valu
   }
   {{field.get_variable_name()}} = value;
 }
-inline void set_{{field.get_name()}}(const {{field.get_type_as_defined()}}&& value)
+inline void set_{{field.get_name()}}({{field.get_type_as_defined()}}&& value)
 {
   if(FieldNumber::{{field.get_variable_id_name()}} != {{field.get_which_oneof()}})
   {
     init_{{field.get_oneof_name()}}(FieldNumber::{{field.get_variable_id_name()}});
   }
-  {{field.get_variable_name()}} = value;
+  {{field.get_variable_name()}} = std::move(value);
 }
 {% elif field.optional %}
 inline bool has_{{field.get_name()}}() const
@@ -72,15 +72,15 @@ inline void set_{{field.get_name()}}(const {{field.get_type_as_defined()}}& valu
   presence_[presence::index(presence::fields::{{field.get_name().upper()}})] |= presence::mask(presence::fields::{{field.get_name().upper()}});
   {{field.get_variable_name()}} = value;
 }
-inline void set_{{field.get_name()}}(const {{field.get_type_as_defined()}}&& value)
+inline void set_{{field.get_name()}}({{field.get_type_as_defined()}}&& value)
 {
   presence_[presence::index(presence::fields::{{field.get_name().upper()}})] |= presence::mask(presence::fields::{{field.get_name().upper()}});
-  {{field.get_variable_name()}} = value;
+  {{field.get_variable_name()}} = std::move(value);
 }
 {% else %}
 inline void clear_{{field.get_name()}}() { {{field.get_variable_name()}}.clear(); }
 inline void set_{{field.get_name()}}(const {{field.get_type_as_defined()}}& value) { {{field.get_variable_name()}} = value; }
-inline void set_{{field.get_name()}}(const {{field.get_type_as_defined()}}&& value) { {{field.get_variable_name()}} = value; }
+inline void set_{{field.get_name()}}({{field.get_type_as_defined()}}&& value) { {{field.get_variable_name()}} = std::move(value); }
 {% endif %}
 inline const {{field.get_type_as_defined()}}& get_{{field.get_name()}}() const { return {{field.get_variable_name()}}.get(); }
 inline {{field.get_type_as_defined()}} {{field.get_name()}}() const { return {{field.get_variable_name()}}.get(); }

--- a/generator/templates/FieldMsg_GetSet.h
+++ b/generator/templates/FieldMsg_GetSet.h
@@ -49,13 +49,13 @@ inline void set_{{field.get_name()}}(const {{field.get_type()}}& value)
   }
   {{field.get_variable_name()}} = value;
 }
-inline void set_{{field.get_name()}}(const {{field.get_type()}}&& value)
+inline void set_{{field.get_name()}}({{field.get_type()}}&& value)
 {
   if(FieldNumber::{{field.get_variable_id_name()}} != {{field.get_which_oneof()}})
   {
     init_{{field.get_oneof_name()}}(FieldNumber::{{field.get_variable_id_name()}});
   }
-  {{field.get_variable_name()}} = value;
+  {{field.get_variable_name()}} = std::move(value);
 }
 inline {{field.get_type()}}& mutable_{{field.get_name()}}()
 {
@@ -80,10 +80,10 @@ inline void set_{{field.get_name()}}(const {{field.get_type()}}& value)
   presence_[presence::index(presence::fields::{{field.get_name().upper()}})] |= presence::mask(presence::fields::{{field.get_name().upper()}});
   {{field.get_variable_name()}} = value;
 }
-inline void set_{{field.get_name()}}(const {{field.get_type()}}&& value)
+inline void set_{{field.get_name()}}({{field.get_type()}}&& value)
 {
   presence_[presence::index(presence::fields::{{field.get_name().upper()}})] |= presence::mask(presence::fields::{{field.get_name().upper()}});
-  {{field.get_variable_name()}} = value;
+  {{field.get_variable_name()}} = std::move(value);
 }
 inline {{field.get_type()}}& mutable_{{field.get_name()}}()
 {
@@ -93,7 +93,7 @@ inline {{field.get_type()}}& mutable_{{field.get_name()}}()
 {% else %}
 inline void clear_{{field.get_name()}}() { {{field.get_variable_name()}}.clear(); }
 inline void set_{{field.get_name()}}(const {{field.get_type()}}& value) { {{field.get_variable_name()}} = value; }
-inline void set_{{field.get_name()}}(const {{field.get_type()}}&& value) { {{field.get_variable_name()}} = value; }
+inline void set_{{field.get_name()}}({{field.get_type()}}&& value) { {{field.get_variable_name()}} = std::move(value); }
 inline {{field.get_type()}}& mutable_{{field.get_name()}}() { return {{field.get_variable_name()}}; }
 {% endif %}
 inline const {{field.get_type()}}& get_{{field.get_name()}}() const { return {{field.get_variable_name()}}; }

--- a/generator/templates/FieldRepeated_GetSet.h
+++ b/generator/templates/FieldRepeated_GetSet.h
@@ -49,13 +49,13 @@ inline void set_{{field.get_name()}}(uint32_t index, const {{field.get_type()}}&
   }
   {{field.get_variable_name()}}.set(index, value);
 }
-inline void set_{{field.get_name()}}(uint32_t index, const {{field.get_type()}}&& value)
+inline void set_{{field.get_name()}}(uint32_t index, {{field.get_type()}}&& value)
 {
   if(FieldNumber::{{field.get_variable_id_name()}} != {{field.get_which_oneof()}})
   {
     init_{{field.get_oneof_name()}}(FieldNumber::{{field.get_variable_id_name()}});
   }
-  {{field.get_variable_name()}}.set(index, value);
+  {{field.get_variable_name()}}.set(index, std::move(value));
 }
 inline void set_{{field.get_name()}}(const {{field.repeated_type}}& values)
 {
@@ -85,7 +85,7 @@ inline {{field.repeated_type}}& mutable_{{field.get_name()}}()
 inline const {{field.get_base_type()}}& {{field.get_name()}}(uint32_t index) const { return {{field.get_variable_name()}}[index]; }
 inline void clear_{{field.get_name()}}() { {{field.get_variable_name()}}.clear(); }
 inline void set_{{field.get_name()}}(uint32_t index, const {{field.get_base_type()}}& value) { {{field.get_variable_name()}}.set(index, value); }
-inline void set_{{field.get_name()}}(uint32_t index, const {{field.get_base_type()}}&& value) { {{field.get_variable_name()}}.set(index, value); }
+inline void set_{{field.get_name()}}(uint32_t index, {{field.get_base_type()}}&& value) { {{field.get_variable_name()}}.set(index, std::move(value)); }
 inline void set_{{field.get_name()}}(const {{field.get_type()}}& values) { {{field.get_variable_name()}} = values; }
 inline void add_{{field.get_name()}}(const {{field.get_base_type()}}& value) { {{field.get_variable_name()}}.add(value); }
 inline {{field.get_type()}}& mutable_{{field.get_name()}}() { return {{field.get_variable_name()}}; }

--- a/generator/templates/TypeDefMsg.h
+++ b/generator/templates/TypeDefMsg.h
@@ -57,7 +57,7 @@ class {{ typedef.get_name() }} final: public ::EmbeddedProto::MessageInterface
       {% endfor %}
     }
 
-    {{ typedef.get_name() }}(const {{typedef.get_name()}}&& rhs ) noexcept
+    {{ typedef.get_name() }}({{typedef.get_name()}}&& rhs ) noexcept
     {
       {% for field in typedef.fields %}
       {% if typedef.optional_fields is defined and field in typedef.optional_fields %}
@@ -120,7 +120,7 @@ class {{ typedef.get_name() }} final: public ::EmbeddedProto::MessageInterface
       return *this;
     }
 
-    {{ typedef.name }}& operator=(const {{ typedef.name }}&& rhs) noexcept
+    {{ typedef.name }}& operator=({{ typedef.name }}&& rhs) noexcept
     {
       {% for field in typedef.fields %}
       {% if typedef.optional_fields is defined and field in typedef.optional_fields %}

--- a/src/Fields.h
+++ b/src/Fields.h
@@ -110,7 +110,7 @@ namespace EmbeddedProto
 
       FieldTemplate() = default;
       FieldTemplate(const VARIABLE_TYPE& v) : value_(v) { };
-      FieldTemplate(const VARIABLE_TYPE&& v) : value_(v) { };
+      FieldTemplate(VARIABLE_TYPE&& v) : value_(std::move(v)) { };
       FieldTemplate(const CLASS_TYPE& ft) : value_(ft.value_) { };
 
       ~FieldTemplate() = default;
@@ -148,17 +148,17 @@ namespace EmbeddedProto
       }
 
       void set(const VARIABLE_TYPE& v) { value_ = v; }      
-      void set(const VARIABLE_TYPE&& v) { value_ = v; }
+      void set(VARIABLE_TYPE&& v) { value_ = std::move(v); }
 
       void set(const CLASS_TYPE& ft) { value_ = ft.value_; }
-      void set(const CLASS_TYPE&& ft) { value_ = ft.value_; }
+      void set(CLASS_TYPE&& ft) { value_ = std::move(ft.value_); }
       
       CLASS_TYPE& operator=(const VARIABLE_TYPE& v) 
       { 
         value_ = v;
         return *this;
       }
-      CLASS_TYPE& operator=(const VARIABLE_TYPE&& v) 
+      CLASS_TYPE& operator=(VARIABLE_TYPE&& v) 
       { 
         value_ = v;
         return *this;
@@ -168,9 +168,9 @@ namespace EmbeddedProto
         value_ = ft.value_; 
         return *this; 
       }
-      CLASS_TYPE& operator=(const CLASS_TYPE&& ft) noexcept
+      CLASS_TYPE& operator=(CLASS_TYPE&& ft) noexcept
       { 
-        value_ = ft.value_;
+        value_ = std::move(ft.value_);
         return *this;
       }
 

--- a/src/RepeatedFieldFixedSize.h
+++ b/src/RepeatedFieldFixedSize.h
@@ -74,7 +74,7 @@ namespace EmbeddedProto
       }
 
       template<uint32_t MAX_LENGTH_RHS, typename std::enable_if<(MAX_LENGTH_RHS < MAX_LENGTH), int>::type = 0>
-      explicit RepeatedFieldFixedSize(const RepeatedFieldFixedSize<DATA_TYPE, MAX_LENGTH_RHS>&& rhs) :
+      explicit RepeatedFieldFixedSize(RepeatedFieldFixedSize<DATA_TYPE, MAX_LENGTH_RHS>&& rhs) :
         current_length_(rhs.get_length())
       {
         const auto& rhs_data = rhs.get_data_const();


### PR DESCRIPTION
_const rvalue reference_ doesn't give any advantages over the copy constructor, so there is no need of defining it, as an _rvalue_ can also be used as a _const lvalue_. This PR creates [move constructors](https://en.cppreference.com/w/cpp/language/move_constructor) which actually move the contents where possible.

One might need to `#include <utility>` for [`std::move()`](https://en.cppreference.com/w/cpp/utility/move) or use a static cast instead as it is equivalent (quoting from the manual):
> It is exactly equivalent to a static_cast to an rvalue reference type. 