### PR TITLE
Add parameter for setup.py to use system libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,10 +200,12 @@ def run(arguments):
         check_protoc_version()
 
         # ---------------------------------------
-        create_venv()
+        if not arguments.system_libs:
+            create_venv()
 
         # ---------------------------------------
-        install_pip()
+        if not arguments.system_libs:
+            install_pip()
 
         # ---------------------------------------
         print("Build the protobuf extension file used to include Embedded Proto custom options.", end='')
@@ -249,6 +251,9 @@ def add_parser_arguments(parser_obj):
     parser_obj.add_argument('-I', '--include', action=ReadableDir,
                             help="Provide the protoc include folder. Required when you installed protoc in a non "
                                  "standard folder, for example: \"~/protobuf/protoc-21.5/include\".")
+
+    # When creating packages for software distributions you might want to use globally installed Python libraries.
+    parser_obj.add_argument("--system-libs", help="Use globally installed Python packages.", action="store_true")
 
 
 ####################################################################################

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,35 @@ def display_feedback():
 
 ####################################################################################
 
+def create_venv():
+    print("Creating a virtual environment for Embedded Proto.", end='')
+    venv.create("venv", with_pip=True)
+    print(" [" + CGREEN + "Success" + CEND + "]")
+
+
+####################################################################################
+
+def install_pip():
+    print("Installing requirement Python packages in the virtual environment.", end='')
+    on_windows = "Windows" == platform.system()
+    command = []
+    if on_windows:
+        command.append("./venv/Scripts/pip")
+    else:
+        command.append("./venv/bin/pip")
+    command.extend(["install", "-r", "requirements.txt"])
+    result = subprocess.run(command, check=False, capture_output=True)
+    if result.returncode:
+        print(" [" + CRED + "Fail" + CEND + "]")
+        print(result.stderr.decode("utf-8"), end='', file=stderr)
+        exit(1)
+    else:
+        print(" [" + CGREEN + "Success" + CEND + "]")
+
+
+####################################################################################
+
+
 def run(arguments):
     # Execute the setup process for Embedded Proto.
 
@@ -171,26 +200,10 @@ def run(arguments):
         check_protoc_version()
 
         # ---------------------------------------
-        print("Creating a virtual environment for Embedded Proto.", end='')
-        venv.create("venv", with_pip=True)
-        print(" [" + CGREEN + "Success" + CEND + "]")
+        create_venv()
 
         # ---------------------------------------
-        print("Installing requirement Python packages in the virtual environment.", end='')
-        on_windows = "Windows" == platform.system()
-        command = []
-        if on_windows:
-            command.append("./venv/Scripts/pip")
-        else:
-            command.append("./venv/bin/pip")
-        command.extend(["install", "-r", "requirements.txt"])
-        result = subprocess.run(command, check=False, capture_output=True)
-        if result.returncode:
-            print(" [" + CRED + "Fail" + CEND + "]")
-            print(result.stderr.decode("utf-8"), end='', file=stderr)
-            exit(1)
-        else:
-            print(" [" + CGREEN + "Success" + CEND + "]")
+        install_pip()
 
         # ---------------------------------------
         print("Build the protobuf extension file used to include Embedded Proto custom options.", end='')
@@ -231,7 +244,7 @@ class ReadableDir(argparse.Action):
 ####################################################################################
 
 def add_parser_arguments(parser_obj):
-    # This function is used to add parameters required by the Embedded Proto script. Setup scripts used in examples 
+    # This function is used to add parameters required by the Embedded Proto script. Setup scripts used in examples
     # now can extend it with their own parameters.
     parser_obj.add_argument('-I', '--include', action=ReadableDir,
                             help="Provide the protoc include folder. Required when you installed protoc in a non "

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def check_protoc_version():
     # package should match.
 
     print("Checking your Protoc version", end='')
-    
+
     try:
         output = subprocess.run(["protoc", "--version"], check=False, capture_output=True)
     except OSError:
@@ -249,6 +249,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     run(args)
-    
+
     # ---------------------------------------
     print("Setup completed with success!")


### PR DESCRIPTION
This is useful for distro packaging of EmbeddedProto where packagers don't want to use a virtualenv but instead use globally installed packages.