### PR TITLE
generator: Use quoted form for dependency include

### DIFF
--- a/generator/templates/Header.h
+++ b/generator/templates/Header.h
@@ -49,7 +49,7 @@
 {% if proto_file.get_dependencies() is defined %}
 // Include external proto definitions
 {% for dependency in proto_file.get_dependencies() %}
-#include <{{dependency}}>
+#include "{{dependency}}"
 {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
Using the angle-bracket form (`#include <foo.h>`) will only look for headers in the compiler include path.

This means that when we output to a subdirectory like:
`$ protoc -I api --eams_out=src/proto api/*.proto`
will fail to compile unless we explicitly add the `src/proto` to the compiler include path with `-I`.