### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build-test:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v2
+      with:
+        version: "21.x"
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+    - name: Install gcovr
+      run: pip install gcovr==5.2
+    - name: Setup venv
+      run: python setup.py
+    - name: Build test
+      run: ./build_test.sh
+    - name: Code coverage
+      run: ./code_coverage.sh

--- a/build_test.sh
+++ b/build_test.sh
@@ -1,5 +1,4 @@
-#! /bin/sh
-
+#!/usr/bin/env bash
 #
 # Copyright (C) 2020-2023 Embedded AMS B.V. - All Rights Reserved
 #
@@ -29,6 +28,9 @@
 #   1627 LE, Hoorn
 #   the Netherlands
 #
+
+# Fail on first non-zero return code
+set -exuo pipefail
 
 # Generate sources using the EAMS plugin.
 mkdir -p ./build/EAMS

--- a/build_test.sh
+++ b/build_test.sh
@@ -62,7 +62,5 @@ protoc -I./test/proto --python_out=./build/python ./test/proto/optional_fields.p
 protoc -I./test/proto -I./generator --python_out=./build/python ./test/proto/field_options.proto
 
 # Build the tests
-mkdir -p build/test
-cd build/test/
-cmake -DCMAKE_BUILD_TYPE=Debug ../../
-make -j16
+cmake -DCMAKE_BUILD_TYPE=Debug -B./build/test
+make -j16 -C ./build/test

--- a/code_coverage.sh
+++ b/code_coverage.sh
@@ -1,12 +1,11 @@
-#! /bin/bash
-
+#!/usr/bin/env bash
 #
 # Copyright (C) 2020-2023 Embedded AMS B.V. - All Rights Reserved
 #
 # This file is part of Embedded Proto.
 #
-# Embedded Proto is open source software: you can redistribute it and/or 
-# modify it under the terms of the GNU General Public License as published 
+# Embedded Proto is open source software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published
 # by the Free Software Foundation, version 3 of the license.
 #
 # Embedded Proto  is distributed in the hope that it will be useful,
@@ -29,6 +28,7 @@
 #   1627 LE, Hoorn
 #   the Netherlands
 #
+set -euxo pipefail
 
 ./build/test/test_EmbeddedProto --gtest_output="xml:build/test/test_details.xml"
 


### PR DESCRIPTION
This adds a CI that can run on third party pull requests.
I understand you are also hosting your own copy on bitbucket, so I've left everything related to those pipelines intact.