### PR TITLE
protoc version mismatch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def check_protoc_version():
         print("Stopping the setup.")
         exit(0)
 
-    version_re_compiled = re.compile(r".*\s(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?")
+    version_re_compiled = re.compile(r".*\s(?P<minor>\d+)\.(?P<patch>\d+)")
     installed_version = version_re_compiled.search(output.stdout.decode("utf-8"))
     required_version = read_required_version()
 


### PR DESCRIPTION
Hello,
when running the `setup.py` script, there is a version mismatch between the major and minor version number.
I installed protoc via the github releases (https://github.com/protocolbuffers/protobuf/releases), and when running `protoc --version` I get: `libprotoc 25.0`.
On the other hand, the python version is `4.25.0`.
According to https://protobuf.dev/support/version-support/, the protoc version number seems to be `minor.patch`, there is no `major` version for protoc.
