### PR TITLE
Fix C++11 build failure in destroy_at

### DIFF
--- a/src/Defines.h
+++ b/src/Defines.h
@@ -61,7 +61,7 @@ namespace EmbeddedProto
 #elif __cplusplus >= 201103L // C++11
 
   template<class T>
-  constexpr void destroy_at(T* p) 
+  inline void destroy_at(T* p) 
   {
     p->~T(); 
   }


### PR DESCRIPTION
## Summary
This fixes a C++11 compatibility issue in `src/Defines.h`.

In the C++11 code path, `destroy_at` was declared as:

- `constexpr void destroy_at(T* p)`

With Apple Clang (C++11), this fails to compile because `constexpr` functions in C++11 cannot have `void` return type.

This change updates the C++11 overload to:

- `inline void destroy_at(T* p)`

C++14 and C++17+ paths are unchanged.

## Why this change
`build_test.sh` fails on C++11 toolchains due to the `constexpr void` declaration, which blocks normal development and CI on affected compilers.

## Validation
- Ran `./build_test.sh` successfully after the change.
- Ran `./build/test/test_EmbeddedProto` successfully (`155` tests passed).

## Scope
- Single-file, minimal change:
  - `src/Defines.h`

## Issue
Closes #89